### PR TITLE
Fix safety-amp agent k8s deployment issues

### DIFF
--- a/k8s/safety-amp/safety-amp-complete.yaml
+++ b/k8s/safety-amp/safety-amp-complete.yaml
@@ -333,7 +333,7 @@ spec:
           timeoutSeconds: 10
         readinessProbe:
           httpGet:
-            path: /health
+            path: /ready
             port: 8080
           initialDelaySeconds: 15
           periodSeconds: 10


### PR DESCRIPTION
Update `safety-amp-agent` readiness probe path to `/ready` to prevent premature traffic routing.

---
<a href="https://cursor.com/background-agent?bcId=bc-46388852-7099-4fd4-a42a-4b4dae559632">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-46388852-7099-4fd4-a42a-4b4dae559632">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

