### PR TITLE
Fix database connection timeout in aks pod

### DIFF
--- a/k8s/safety-amp/safety-amp-complete.yaml
+++ b/k8s/safety-amp/safety-amp-complete.yaml
@@ -162,6 +162,8 @@ spec:
         - containerPort: 9090
           name: metrics
         env:
+        - name: AZURE_CLIENT_ID
+          value: "a2bcb3ce-a89b-43af-804c-e8029e0bafb4"
         - name: LOG_LEVEL
           valueFrom:
             configMapKeyRef:
@@ -326,18 +328,19 @@ spec:
             cpu: "200m"
         livenessProbe:
           httpGet:
-            path: /health
+            path: /live
             port: 8080
-          initialDelaySeconds: 30
-          periodSeconds: 30
-          timeoutSeconds: 10
+          initialDelaySeconds: 10
+          periodSeconds: 20
+          timeoutSeconds: 5
         readinessProbe:
           httpGet:
             path: /ready
             port: 8080
-          initialDelaySeconds: 15
+          initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5
+          failureThreshold: 6
         volumeMounts:
         - name: changes-volume
           mountPath: /app/output/changes


### PR DESCRIPTION
Decouple liveness from readiness and optimize DB connection timeouts to improve pod startup and stability.

The pod was failing to become ready due to database login timeouts, as the liveness probe was tied to DB health. This change introduces separate `/live` and `/ready` endpoints, allowing the liveness probe to ensure the container is running even if the database is temporarily unavailable, while the readiness probe accurately reflects DB connectivity. SQL connection timeouts were also reduced to prevent prolonged blocking on connection attempts.

---
<a href="https://cursor.com/background-agent?bcId=bc-f876fb94-1e8c-4860-9b30-c9f18f83e290">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f876fb94-1e8c-4860-9b30-c9f18f83e290">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

